### PR TITLE
refactor signal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### v2.3.1
+### v2.4.0
 * Reverted failed SIGWINCH handling
 * Added handling for terminal job system (SIGSTP/SIGCONT)
+* Added new functions for custom handlers for the user
 
 ### v2.3.0
 * Added handling for SIGWINCH (Sig win change) for terminal resizing

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -11,8 +11,11 @@
 // show it's output as a Key object in the terminal. Press `q` to quit.
 
 int main() {
-  rawterm::enable_raw_mode(true);
+  rawterm::enable_raw_mode();
   rawterm::enter_alt_screen();
+  rawterm::enable_signals();
+
+  rawterm::clear_screen();
   rawterm::Pos size = rawterm::get_term_size();
   std::cout << "Term size: " << size.vertical << ", " << size.horizontal
             << "\r\n";


### PR DESCRIPTION
TLDR I now have a boolean set with the `rawterm::enable_signals();` function and then in the keybind processing for ctrl+c and ctrl+z, if the boolean is set, I call the relevant signals. This is easier to expand on. I'm hoping this attempt now should make more sense for my text editor project -- but I'm not sure if this allows for the user to expand on what happens when a signal is sent -- I think the user can add their own signal handler as well as the one being called by the library (rawterm.h lines 166-173)